### PR TITLE
add a reusable linting github action workflow

### DIFF
--- a/.github/workflows/lint-reusable.yml
+++ b/.github/workflows/lint-reusable.yml
@@ -1,0 +1,25 @@
+# This workflow defines a reusable Go linting flow, using Golangci-lint: https://golangci-lint.run/
+# If you want use this workflow, you might want to add some configurations to your repository:
+# https://golangci-lint.run/usage/configuration/
+name: Lint code (reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod" # This uses the Go version defined in the mod file, in contrast to setting a defined version.
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.55
+          args: --timeout=5m


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- adds a reusable GitHub action workflow, that runs a Go linter base on [Golangci-lint](https://golangci-lint.run/)

This change will allow us to re-use the same linting workflow between multiple repos and in multiple workflows, e.g., `Create release`.

This was tested by implementing the same workflow [here](https://github.com/friedrichwilken/reusable-workflows/blob/main/.github/workflows/lint-code-reusable.yml) and then, calling it from [this repo](https://github.com/friedrichwilken/test-gha/blob/c21dfbd13b9170fb9ed981f9a2d84e58dab165e4/.github/workflows/unit-test.yml#L29), resulted in a successful detection of linting issues in [this dummy PR](https://github.com/friedrichwilken/test-gha/actions/runs/7562923583/job/20594348085?pr=1).

**Related issue(s)**
https://github.com/kyma-project/eventing-manager/issues/361