### PR TITLE
use a commit sha for script instead of main

### DIFF
--- a/.github/workflows/create-draft-release-reusable.yml
+++ b/.github/workflows/create-draft-release-reusable.yml
@@ -28,9 +28,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         shell: bash
         run: |
-          # todo once the script was merged replace main with a commit sha:
-          # curl -sSL https://raw.githubusercontent.com/kyma-project/eventing-tools/<your-sha>/hack/scripts/create_changelog.sh | bash "${VERSION}"
-          curl -sL https://raw.githubusercontent.com/kyma-project/eventing-tools/main/hack/scripts/create_changelog.sh | bash "${VERSION}"
+          curl -sL https://raw.githubusercontent.com/kyma-project/eventing-tools/b3ca34f38eb11a70bbde9a830bb86d9f069fb0fa/hack/scripts/create_changelog.sh | bash -s "${VERSION}"
 
       - name: Print out changelog
         run: cat CHANGELOG.md


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->



**Description**

Changes proposed in this pull request:

- download the `create-changelog.sh` via a commit sha in the `create draft release` reusable workflow
- add the missing flag `-s` to `bash` 

The sha points to this commit: https://github.com/kyma-project/eventing-tools/commit/b3ca34f38eb11a70bbde9a830bb86d9f069fb0fa

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
