### PR TITLE
get branch-name from github var

### DIFF
--- a/.github/workflows/trigger-prow-build-job-reusable.yml
+++ b/.github/workflows/trigger-prow-build-job-reusable.yml
@@ -63,6 +63,6 @@ jobs:
           GITHUB_REPO: ${{ github.event.repository.name }}
         with:
           context: "${{ inputs.CONTEXT }}"
-          commit_ref: "release-${VERSION}" # the name of the release branch.
+          commit_ref: ${{ GITHUB_REF_NAME }} # the name of the release branch.
           timeout: ${{ inputs.TIMEOUT }}
           check_interval: ${{ inputs.INTERVAL }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

There was a bug in the workflow that would pass the wrong branch name:
for the branch `release-1.0` the input "release-${VERSION}" would generate the name `release-1.0.x` because the `VERSION` always has three numbers instead of the two of the branch name. So, this PR changes this use `${{ GITHUB_REF_NAME }}` to get the var.

e.g. we are on branch `release-1.0`; the generated version would be `release-1.0.1`.
`"release-${VERSION}"` would lead to the branch name `release-1.0.1` instead of `release-1.0`.

[Docs](https://docs.github.com/en/actions/learn-github-actions/variables) for `GITHUB_REF_NAME`:
> The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, `feature-branch-1`. For pull requests, the format is `<pr_number>/merge`.

**Related issue(s)**
[issue](https://github.com/kyma-project/eventing-manager/issues/361)
