### PR TITLE
pass-commit-ref-as-input

### DIFF
--- a/.github/workflows/trigger-prow-build-job-reusable.yml
+++ b/.github/workflows/trigger-prow-build-job-reusable.yml
@@ -3,6 +3,10 @@ name: Trigger prow build job (reusable)
 on:
   workflow_call:
     inputs:
+      COMMIT_REF:
+        required: true
+        type: string
+        description: The commit ref for the `wait-for-commit-status-action` action. This should be the branch name from where the release was triggered.
       VERSION:
         required: true
         type: string
@@ -63,6 +67,6 @@ jobs:
           GITHUB_REPO: ${{ github.event.repository.name }}
         with:
           context: "${{ inputs.CONTEXT }}"
-          commit_ref: ${{ GITHUB_REF_NAME }} # the name of the release branch.
+          commit_ref: ${{ inputs.COMMIT_REF }}
           timeout: ${{ inputs.TIMEOUT }}
           check_interval: ${{ inputs.INTERVAL }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Calling this workflow will cause the error:
```
The workflow is not valid. In .github/workflows/create-release.yml (Line: 39, Col: 11): Error from called workflow kyma-project/eventing-tools/.github/workflows/trigger-prow-build-job-reusable.yml@7113a71873561bf9387f647ae39d275eab5dbd7a (Line: 66, Col: 23): Unrecognized named-value: 'GITHUB_REF_NAME'. Located at position 1 within expression: GITHUB_REF_NAME
```
So let's pass the `commit_ref` from the caller workflow, where `GITHUB_REF_NAME` is available.
**Related issue(s)**
[issue](https://github.com/kyma-project/eventing-manager/issues/361)
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
