### PR TITLE
Fix get version

### DIFF
--- a/.github/workflows/get-version-from-release-branch-reusable.yml
+++ b/.github/workflows/get-version-from-release-branch-reusable.yml
@@ -35,11 +35,15 @@ jobs:
           MINOR: ${{ env.MINOR }}
         run: |
           TAGS=$(git tag -l "$MAJOR.$MINOR.*")
-          if [[ -z $TAGS ]]; then
-            PATCH=0
+          if [[ -n $TAGS ]]; then
+            # -n tests for a non-zero-length string
+            LAST_PATCH=$(echo "$TAGS" | cut -d '.' -f  3 | sort -n | tail -n  1)
+            PATCH=$((LAST_PATCH +  1))
           else
-            PATCH=$(( $(echo $TAGS | cut -d '.' -f 3 | sort -n | tail -n 1) + 1))
+            # If TAGS is empty, PATCH defaults to  0
+            PATCH=0
           fi
-          VERSION="${MAJOR}.${MINOR}.${PATCH:-0}"
+          VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "version: ${VERSION}"
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           exit 0


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- the script `create_changelog.sh` does not work so let's revert it to almost the original state from [nats-manger](https://github.com/kyma-project/nats-manager/blob/main/.github/scripts/create_changelog.sh) and only allow entering the repo, in addition
- the workflow `get-version-from-branch` was always producing `0` for the patch version, e.g. `0.8.0`. This PR makes it properly increment the patch version by 1.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
