### PR TITLE
feat: add external-images-syncer workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,12 @@ on:
   push:
     branches: [ "main" ]
     tags: [ '*.*.*' ]
+    paths-ignores:
+      - 'external-images.yml'
   pull_request:
     branches: [ "main" ]
+    paths-ignores:
+      - 'external-images.yml'
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/sync-external-images.yml
+++ b/.github/workflows/sync-external-images.yml
@@ -1,0 +1,25 @@
+
+name: sync-external-images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "external-images.yml"
+  pull_request_target:
+    types: [ opened, edited, synchronize, reopened, ready_for_review ]
+    branches:
+      - main
+    paths:
+      - "external-images.yml"
+
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
+jobs:
+  sync-external-images:
+    uses: kyma-project/test-infra/.github/workflows/image-syncer.yml@main
+    with:
+      debug: true

--- a/external-images.yml
+++ b/external-images.yml
@@ -1,0 +1,5 @@
+
+images:
+  - source: golang@sha256:2d40d4fc278dad38be0777d5e2a88a2c6dee51b0b29c97a764fc6c6a11ca893c
+    tag: 1.24.0-alpine3.2
+    amd64Only: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

External images are no longer handled centrally in [`test-infra`](https://github.com/kyma-project/test-infra) but have to be taken care of per team by utilizing the [`image-syncer` workflow](https://github.com/kyma-project/test-infra/tree/main/cmd/image-syncer#user-guide). This is the implementation of this workflow for eventing. 

Changes proposed in this pull request:

- add the image-syncer workflow
- changes to `external-images` will no longer trigger the build job.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
