### PR TITLE
deps: bump langfuse images to version 3.43.0, as used in langfuse-k8s 1.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,16 @@ on:
   push:
     branches: [ "main" ]
     tags: [ '*.*.*' ]
-    paths-ignores:
-      - 'external-images.yaml'
+    paths:
+      - '**.go'
+      - go.mod
+      - Dockerfile
   pull_request:
     branches: [ "main" ]
-    paths-ignores:
-      - 'external-images.yaml'
+    paths:
+      - '**.go'
+      - go.mod
+      - Dockerfile
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,13 +5,17 @@ on:
       - v*
     branches:
       - main
-    paths-ignores:
-      - 'external-images.yaml'
+    paths:
+      - '**.go'
+      - go.mod
+      - Dockerfile
   pull_request:
     branches:
       - main
-    paths-ignores:
-      - 'external-images.yaml'
+    paths:
+      - '**.go'
+      - go.mod
+      - Dockerfile
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.

--- a/external-images.yaml
+++ b/external-images.yaml
@@ -9,11 +9,11 @@ images:
   - source: bitnami/clickhouse@sha256:3cf6544f6c6cd33f6cc4960bc4a237de5e95a0df35af2bfbf6cc6073754fea04
     tag: 24.12.3-debian-12-r1
     amd64Only: true
-  - source: langfuse/langfuse@sha256:30a586389ff038f43b3ab9bcd54e33720fe77f583b790362c1db6a324513ae3e
-    tag: 3.28.3
+  - source: langfuse/langfuse@sha256:689db3d12ebf03eed83035a79d78bc431b6c94921387f3db0e7ef079b84165a8
+    tag: 3.43.0
     amd64Only: true
-  - source: langfuse/langfuse-worker@sha256:6fe855949aa96c5596b8f0b93b5216653e92c8f3f7b2dad1f2845623d3bb0c60
-    tag: 3.28.3
+  - source: langfuse/langfuse-worker@sha256:91162af09373f20b022114a795b81b2c92f69f5c04b1b51bc1cf8e888e635d73
+    tag: 3.43.0
     amd64Only: true
   - source: bitnami/zookeeper@sha256:6f2bdff0e22c3b156f40fac40bc163b97254b699b1c224cb491df6d51dc023a1
     tag: 3.9.3-debian-12-r3


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- bump `langfuse` and `langfuse-worker` images to version `3.43.0`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
