### PR TITLE
chore: add nats config reloader to external images

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,5 +1,8 @@
 
 images:
+  - source: "natsio/nats-server-config-reloader@sha256:bca7e221ec6f1221ecd74e2c13b075c913a5bcd998e87a4da4d747033440ee93"
+    tag: 0.18.2
+    amd64Only: true
   - source: "golang@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a"
     tag: 1.24.4-alpine3.22
     amd64Only: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add the latest version of nats-external-config-reloader image (0.18.2) to the external images

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
