### PR TITLE
deps: bump golang image 1.25.1:alpine3.22

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,4 +1,3 @@
-
 images:
   - source: "natsio/prometheus-nats-exporter@sha256:26c826662ac8424597cc9bdf89ea5b606eb66e3c11db9b1215c27d2076bbb01b"
     tag: 0.17.3
@@ -6,21 +5,6 @@ images:
   - source: "natsio/nats-server-config-reloader@sha256:bca7e221ec6f1221ecd74e2c13b075c913a5bcd998e87a4da4d747033440ee93"
     tag: 0.18.2
     amd64Only: true
-  - source: "golang@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a"
-    tag: 1.24.4-alpine3.22
-    amd64Only: true
-  - source: python@sha256:28b8a72c4e0704dd2048b79830e692e94ac2d43d30c914d54def6abf74448a4e
-    tag: 3.12-alpine3.21
-    amd64Only: true
-  - source: bitnami/clickhouse@sha256:3cf6544f6c6cd33f6cc4960bc4a237de5e95a0df35af2bfbf6cc6073754fea04
-    tag: 24.12.3-debian-12-r1
-    amd64Only: true
-  - source: langfuse/langfuse@sha256:90e1cf747c0815cdf8fe458efe9059f6430e673d93a103c4b60fddfe5e92218f
-    tag: 3.63.0
-    amd64Only: true
-  - source: langfuse/langfuse-worker@sha256:d77fdb447cda3ebad266641f504578eb8bf35e02e2bb3492378c19db7caa9353
-    tag: 3.63.0
-    amd64Only: true
-  - source: bitnami/zookeeper@sha256:6f2bdff0e22c3b156f40fac40bc163b97254b699b1c224cb491df6d51dc023a1
-    tag: 3.9.3-debian-12-r3
+  - source: "golang@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd"
+    tag: 1.25.1-alpine3.22
     amd64Only: true


### PR DESCRIPTION
and remove images unrelated to eventing

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- bump external image syncer golang image to `1.25.1-alpine3.22`
- remove image unrelated to eventing

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
